### PR TITLE
Solution for Day 2's exercise

### DIFF
--- a/02 - JS and CSS Clock/index-START.html
+++ b/02 - JS and CSS Clock/index-START.html
@@ -5,17 +5,13 @@
   <title>JS + CSS Clock</title>
 </head>
 <body>
-
-
-    <div class="clock">
-      <div class="clock-face">
-        <div class="hand hour-hand"></div>
-        <div class="hand min-hand"></div>
-        <div class="hand second-hand"></div>
-      </div>
+  <div class="clock">
+    <div class="clock-face">
+      <div class="hand hour-hand"></div>
+      <div class="hand min-hand"></div>
+      <div class="hand second-hand"></div>
     </div>
-
-
+  </div>
   <style>
     html {
       background: #018DED url(https://unsplash.it/1500/1000?image=881&blur=5);
@@ -62,13 +58,47 @@
       background: black;
       position: absolute;
       top: 50%;
+      transform-origin: 100%;
+      transform: rotate(90deg);
+      transition: all 0.05s;
+      transition-timing-function: cubic-bezier(0.1, 2.7, 0.58, 1);
     }
 
+    .notransition {
+      -webkit-transition: none !important;
+      -moz-transition: none !important;
+      -o-transition: none !important;
+      transition: none !important;
+    }
   </style>
 
   <script>
+    window.addEventListener('DOMContentLoaded', setDate);
+    setInterval(setDate, 1000);
 
+    const secondsHand = document.querySelector('.second-hand');
+    const minsHand = document.querySelector('.min-hand');
+    const hoursHand = document.querySelector('.hour-hand');
 
+    function setDate() {
+      const now = new Date();
+
+      const seconds = now.getSeconds();
+      const secondsDeg = (((seconds / 60) * 360) + 90);
+      if (seconds == 0) secondsHand.classList.add('notransition');
+      else if (Array.from(secondsHand.classList).includes('notransition')) {
+        secondsHand.classList.remove('notransition')
+      }
+      secondsHand.style.transform = `rotate(${secondsDeg}deg)`;
+
+      const minutes = now.getMinutes();
+      const minsDeg = (((minutes / 60) * 360) + 90);
+      minsHand.style.transform = `rotate(${minsDeg}deg)`;
+      
+      const hours = now.getHours();
+      const hoursDeg = (((hours / 12) * 360) + 90);
+      hoursHand.style.transform = `rotate(${hoursDeg}deg)`;
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Notes

- It was key 🔑  to define what would trigger the function that would move the hands of the clock. In this case, we used the setInterval() Web API to run the setDate function every second. 

- When working with the DOM, we'll often need to translate a value –say, a number– into a unit of measure that we can use in CSS. For example, we "translated" the number of seconds into degrees to pass to the rotate() CSS function. It's crucial to figure out these relationships so we can do these "translations" programmatically. 

- The very first call to `setDate()` was always going to happen at least 1 second after the DOM had loaded. Why? Because the `setInterval API` would be triggered as soon as that line was executed, but the setDate callback was going to be added first to the CallBack Queue and only added to the Call Stack was the rest of the synchronous code had  finished executing. The "problem" was that all the hands of the clock would start at zero and have to wait at least one second to move to their position according to the current time.
  - For this reason, I registered an event listener on the 
window object to listen for the `'DOMContentLoaded'` trigger and used setDate as the callback. The result was that the clock would be set to the current time by calling setDate as soon as the DOM had loaded vs. having to wait for 1 full second.

- When seconds was 0, the the CSS transition property on the hand div would make the hand travel backward to be rotated 90 degrees (given that all transitions had a duration of 0.05s and all hands had a `transform: rotate(90deg)` applied to them). 
  - This is why I added an if statement to check if seconds was equal to 0 (which was equivalent to the transform: rotate() on the seconds hand to be set to 90deg). If it was, I added a class of `'notransition'` to set the transition property to none. If seconds was any value other than zero, I checked if the secondsHand element had the `'notransition'` and removed it.


## Learned anything new?

- The `transform-origin` property's value is set to 50% on the X axis by default, so all transformations happen from the horizontal center of the element. In this case, the transformation needed to happen from the right-hand side of the element, and setting `transform-origin: 100%` allowed us to do that.  
