### PR TITLE
Play with HTML5 Canvas

### DIFF
--- a/08 - Fun with HTML5 Canvas/index-START.html
+++ b/08 - Fun with HTML5 Canvas/index-START.html
@@ -7,6 +7,52 @@
 <body>
 <canvas id="draw" width="800" height="800"></canvas>
 <script>
+  const canvas = document.getElementById('draw');
+  const ctx = canvas.getContext('2d');
+  
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  ctx.strokeStyle = "#BADA55";
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+  ctx.lineWidth = 30;
+
+  let isDrawing = false;
+  let lastX = 0;
+  let lastY = 0;
+  let hue = 0;
+  let direction = true;
+
+  function draw(e) {
+    if (!isDrawing) return;
+    ctx.strokeStyle = `hsl(${hue}, 100%, 50%)`
+    ctx.beginPath();
+    ctx.moveTo(lastX, lastY);
+    ctx.lineTo(e.offsetX, e.offsetY)
+    ctx.stroke();
+    [lastX, lastY] = [e.offsetX, e.offsetY]
+    hue++;
+    if (hue >= 360) {
+      hue = 0;
+    }
+    if (ctx.lineWidth >= 100 || ctx.lineWidth <= 1) {
+      direction = !direction;
+    }
+    if (direction) {
+      ctx.lineWidth++;
+    } else {
+      ctx.lineWidth--;
+    }
+  }
+
+  canvas.addEventListener('mousedown', (e) => {
+    isDrawing = true;
+    [lastX, lastY] = [e.offsetX, e.offsetY]
+  })
+  
+  canvas.addEventListener('mousemove', draw)
+  canvas.addEventListener('mouseup', () => isDrawing = false)
+  canvas.addEventListener('mouseout', () => isDrawing = false)
 </script>
 
 <style>


### PR DESCRIPTION
## Notes
The HTML5 `canvas` element allows us to draw on a webpage. Using its `getContext()` property and setting it's height and width, we can define what type of drawing we'll be able to do (wether it's 2D or 3D space) and the size of the canvas we have for drawing.

## Big takeaway 🍱 🥡 
Aside from learning about the canvas element, the big lesson here comes from the following lines of code: 

```
  canvas.addEventListener('mousedown', (e) => {
    isDrawing = true;
    [lastX, lastY] = [e.offsetX, e.offsetY]
  })
  
  canvas.addEventListener('mousemove', draw)
  canvas.addEventListener('mouseup', () => isDrawing = false)
  canvas.addEventListener('mouseout', () => isDrawing = false)
```
Where we update the `isDrawing` flag based on the type of event trigger on the same `canvas` element we'll be drawing onto when `isDrawing` is set to `true`. We check for the value of `isDrawing` inside our `draw` function, and return if it's `false`: 

```
function draw(e) {
  if (!isDrawing) return; 
  // do the rest of the code only when isDrawing is true
  ...
}   
```

On the `mousedown` event trigger, we also update the values for two global variables to start drawing from where our mouse was when we pressed down: 

```
canvas.addEventListener('mousedown', (e) => {
    isDrawing = true;
    [lastX, lastY] = [e.offsetX, e.offsetY]
  })
```

## Learned anything new?
- Using a "flag" variable (like `isDrawing`) allows us to do something or not inside an event handler by checking if this "flag" is true or false. This pattern happens over and over in JavaScript.
  -One sort of "sub-application" for this pattern is setting a variable to be the opposite of what it currently is: 

```
let direction = true;
....
if (someCondition) {
  direction = !direction;
}
```


- HSL color notation (`hsl(hue, saturation, lightness)`) can be useful when we need to update colors programatically. 
