### PR TITLE
Day 25 solution

### DIFF
--- a/25 - Event Capture, Propagation, Bubbling and Once/index-START.html
+++ b/25 - Event Capture, Propagation, Bubbling and Once/index-START.html
@@ -40,9 +40,27 @@
   }
 </style>
 
-<button></button>
-<script>
+<button>Button</button>
 
+<script>
+  const divs = document.querySelectorAll('div');
+  const button = document.querySelector('button');
+  
+  function logText(e) {
+    console.log(this.classList.value)
+    e.stopPropagation();
+  }
+
+  divs.forEach(div => div.addEventListener('click', logText, {
+    capture: false, 
+    once: true
+  }))
+
+  button.addEventListener('click', () => {
+    console.log('Click!')
+  }, {
+    once: true
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Notes

Working with events can be tricky. Why? 

- Event objects have properties that vary according to which type of event is triggered. https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_objects

- This means that there are different things we can do inside our event handler functions, and sometimes we will be able to do one thing but not another.

- Sometimes, you'll come across a situation where you want to prevent an event from doing what it does by default. You can use `e.preventDefault()`
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#preventing_default_behavior

- Additionally, event bubbling and capture are two mechanisms that describe what happens when two handlers of the same event type are activated on one element, or what happens when an element and its parents (or children!) are listening for the same event type.

## Bubbling and capturing explained (MDN) 
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture

When an event is fired on an element that has parent elements (in this case, the <video> has the <div> as a parent), modern browsers run two different phases — the capturing phase and the bubbling phase.

**In the capturing phase:**

- The browser checks to see if the element's outer-most ancestor (<html>) has an onclick event handler registered on it for the capturing phase, and runs it if so.

- Then it moves on to the next element inside <html> and does the same thing, then the next one, and so on until it reaches the element that was actually selected.

**In the bubbling phase, the exact opposite occurs:**

- The browser checks to see if the element selected has an onclick event handler registered on it for the bubbling phase, and runs it if so.

- Then it moves on to the next immediate ancestor element and does the same thing, then the next one, and so on until it reaches the <html> element.

**In modern browsers, by default, all event handlers are registered for the bubbling phase.** So in our current example, when you select the video, the event bubbles from the <video> element outwards to the <html> element. Along the way:

- It finds the video.onclick... handler and runs it, so the video first starts playing.
- It then finds the videoBox.onclick... handler and runs it, so the video is hidden as well.

By passing an options `Object {}`, we can update the default behaviors for both the bubbling and capturing phases, and do other things like set handlers to only run once: 

```
 divs.forEach(div => div.addEventListener('click', logText, {
    capture: false,  //default behavior, but we could set it to true if we wanted events to be triggered on the capturing phase
    once: true //handler will only run once for each div
  }))
```

**Fixing the problem with stopPropagation()**

This is a very annoying behavior, but there is a way to fix it! The standard Event object has a function available on it called `stopPropagation()` which, when invoked on a handler's event object, makes it so that first handler is run but the event doesn't bubble any further up the chain, so no more handlers will be run.